### PR TITLE
update update-opentracing-api to 0.33.0 and fix issues

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,10 @@ checkstyle {
     configFile = new File(rootDir, "checkstyle.xml")
 }
 
+jacoco {
+    toolVersion = "0.8.6"
+}
+
 jacocoTestReport {
     reports {
         xml.enabled true

--- a/build.gradle
+++ b/build.gradle
@@ -20,11 +20,11 @@ repositories {
 }
 
 dependencies {
-    api group: 'io.opentracing', name: 'opentracing-api', version: '0.31.0'
+    api group: 'io.opentracing', name: 'opentracing-api', version: '0.33.0'
     implementation group: 'com.amazonaws', name: 'aws-java-sdk-sqs', version: '1.11.464'
     implementation group: 'software.amazon.awssdk', name: 'sqs', version: '2.1.3'
 
-    testImplementation group: 'io.opentracing', name: 'opentracing-mock', version: '0.31.0'
+    testImplementation group: 'io.opentracing', name: 'opentracing-mock', version: '0.33.0'
     testImplementation group: 'junit', name: 'junit', version: '4.12'
 }
 

--- a/src/main/java/org/zalando/opentracing/sqs/SQSTracing.java
+++ b/src/main/java/org/zalando/opentracing/sqs/SQSTracing.java
@@ -24,7 +24,8 @@ import java.util.Map;
 import java.util.Optional;
 
 import static io.opentracing.References.FOLLOWS_FROM;
-import static io.opentracing.propagation.Format.Builtin.TEXT_MAP;
+import static io.opentracing.propagation.Format.Builtin.TEXT_MAP_INJECT;
+import static io.opentracing.propagation.Format.Builtin.TEXT_MAP_EXTRACT;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 
@@ -123,7 +124,7 @@ public final class SQSTracing {
 
         if (spanContext != null) {
             final Map<String, String> contextMap = new HashMap<>();
-            tracer.inject(spanContext, TEXT_MAP, new TextMapInjectAdapter(contextMap));
+            tracer.inject(spanContext, TEXT_MAP_INJECT, new TextMapInjectAdapter(contextMap));
             request.addMessageAttributesEntry(
                 attributeKey,
                 new com.amazonaws.services.sqs.model.MessageAttributeValue()
@@ -157,7 +158,7 @@ public final class SQSTracing {
 
         if (spanContext != null) {
             final Map<String, String> contextMap = new HashMap<>();
-            tracer.inject(spanContext, TEXT_MAP, new TextMapInjectAdapter(contextMap));
+            tracer.inject(spanContext, TEXT_MAP_INJECT, new TextMapInjectAdapter(contextMap));
             request.addMessageAttributesEntry(
                 attributeKey,
                 new com.amazonaws.services.sqs.model.MessageAttributeValue()
@@ -213,7 +214,7 @@ public final class SQSTracing {
 
         if (spanContext != null) {
             final Map<String, String> contextMap = new HashMap<>();
-            tracer.inject(spanContext, TEXT_MAP, new TextMapInjectAdapter(contextMap));
+            tracer.inject(spanContext, TEXT_MAP_INJECT, new TextMapInjectAdapter(contextMap));
             request.getEntries().forEach(entry ->
                 entry.addMessageAttributesEntry(
                     attributeKey,
@@ -425,7 +426,7 @@ public final class SQSTracing {
         if (activate) {
             // it does not make sense to finish the span on close,
             // because it will get transferred to another system via the queue for finishing.
-            tracer.scopeManager().activate(span, false);
+            tracer.scopeManager().activate(span);
         }
 
         return span;
@@ -443,7 +444,7 @@ public final class SQSTracing {
      */
     private Optional<SpanContext> safeExtract(final Map<String, String> contextMap) {
         try {
-            return Optional.ofNullable(tracer.extract(TEXT_MAP, new TextMapExtractAdapter(contextMap)));
+            return Optional.ofNullable(tracer.extract(TEXT_MAP_EXTRACT, new TextMapExtractAdapter(contextMap)));
         } catch (IllegalArgumentException e) {
             return Optional.empty();
         }
@@ -481,7 +482,7 @@ public final class SQSTracing {
 
         final Map<String, MessageAttributeValue> tracedAttributes = new HashMap<>(attributes);
         final Map<String, String> contextMap = new HashMap<>();
-        tracer.inject(spanContext, TEXT_MAP, new TextMapInjectAdapter(contextMap));
+        tracer.inject(spanContext, TEXT_MAP_INJECT, new TextMapInjectAdapter(contextMap));
         tracedAttributes.put(attributeKey,
             MessageAttributeValue.builder().dataType(STRING_DATA_TYPE).stringValue(jsonEncode(contextMap)).build());
 

--- a/src/test/java/org/zalando/opentracing/sqs/CreateQueueingSpanTest.java
+++ b/src/test/java/org/zalando/opentracing/sqs/CreateQueueingSpanTest.java
@@ -17,8 +17,8 @@ public class CreateQueueingSpanTest {
 
     @Test
     public void spanMustBeCreatedCorrectlyWithParentSpan() {
-        mockTracer.buildSpan("meep").startActive(true).span()
-            .setBaggageItem("baggage-key", "baggage-value");
+        mockTracer.activateSpan(mockTracer.buildSpan("meep").start()
+                .setBaggageItem("baggage-key", "baggage-value"));
 
         final MockSpan parent = (MockSpan) mockTracer.activeSpan();
         final MockSpan span = (MockSpan) new SQSTracing(mockTracer)

--- a/src/test/java/org/zalando/opentracing/sqs/SQSTracingTest.java
+++ b/src/test/java/org/zalando/opentracing/sqs/SQSTracingTest.java
@@ -39,7 +39,7 @@ public class SQSTracingTest {
 
     @Test
     public void producerMustLeaveRequestUnchangedForNullSpanContext() {
-        mockTracer.buildSpan("meep").startActive(true).span()
+        mockTracer.buildSpan("meep").start()
             .setBaggageItem("baggage-key", "baggage-value");
 
         final SendMessageRequest request = request();
@@ -51,8 +51,8 @@ public class SQSTracingTest {
 
     @Test
     public void producerMustAddSpanContextToSingleMessage() throws IOException {
-        mockTracer.buildSpan("meep").startActive(true).span()
-            .setBaggageItem("baggage-key", "baggage-value");
+        mockTracer.activateSpan(mockTracer.buildSpan("meep").start()
+                .setBaggageItem("baggage-key", "baggage-value"));
 
         final String customName = "span_context";
 
@@ -83,7 +83,7 @@ public class SQSTracingTest {
 
     @Test
     public void producerMustAddExplicitSpanContextToSingleMessage() throws IOException {
-        mockTracer.buildSpan("meep").startActive(true).span()
+        mockTracer.buildSpan("meep").start()
             .setBaggageItem("baggage-key", "baggage-value");
         final Span inactive = mockTracer.buildSpan("bleep").start()
             .setBaggageItem("baggage-key", "bleep-value");
@@ -118,7 +118,7 @@ public class SQSTracingTest {
 
     @Test
     public void producerMustLeaveBatchEntryUnchangedForNullSpanContext() {
-        mockTracer.buildSpan("meep").startActive(true).span()
+        mockTracer.buildSpan("meep").start()
             .setBaggageItem("baggage-key", "baggage-value");
 
         final SendMessageBatchRequestEntry entry = entry();
@@ -131,8 +131,8 @@ public class SQSTracingTest {
 
     @Test
     public void producerMustAddSpanContextToBatchEntry() throws IOException {
-        mockTracer.buildSpan("meep").startActive(true).span()
-            .setBaggageItem("baggage-key", "baggage-value");
+        mockTracer.activateSpan(mockTracer.buildSpan("meep").start()
+                .setBaggageItem("baggage-key", "baggage-value"));
 
         final SendMessageBatchRequestEntry request = entry();
         final SendMessageBatchRequestEntry tracedRequest = new SQSTracing(mockTracer)
@@ -161,7 +161,7 @@ public class SQSTracingTest {
 
     @Test
     public void producerMustAddExplicitSpanContextToBatchEntry() throws IOException {
-        mockTracer.buildSpan("meep").startActive(true).span()
+        mockTracer.buildSpan("meep").start()
             .setBaggageItem("baggage-key", "baggage-value");
         final Span inactive = mockTracer.buildSpan("bleep").start()
             .setBaggageItem("baggage-key", "bleep-value");
@@ -197,7 +197,7 @@ public class SQSTracingTest {
 
     @Test
     public void producerMustLeaveBatchRequestUnchangedForNullSpanContext() {
-        mockTracer.buildSpan("meep").startActive(true).span()
+        mockTracer.buildSpan("meep").start()
             .setBaggageItem("baggage-key", "baggage-value");
 
         final SendMessageBatchRequest request = batch();
@@ -226,8 +226,8 @@ public class SQSTracingTest {
 
     @Test
     public void producerMustAddSpanContextToWholeMessageBatch() {
-        mockTracer.buildSpan("meep").startActive(true).span()
-            .setBaggageItem("baggage-key", "baggage-value");
+        mockTracer.activateSpan(mockTracer.buildSpan("meep").start()
+                .setBaggageItem("baggage-key", "baggage-value"));
 
         final SendMessageBatchRequest request = batch();
         final SendMessageBatchRequest tracedRequest = new SQSTracing(mockTracer).injectInto(request);
@@ -261,7 +261,7 @@ public class SQSTracingTest {
 
     @Test
     public void producerMustAddExplicitSpanContextToWholeMessageBatch() {
-        mockTracer.buildSpan("meep").startActive(true).span()
+        mockTracer.buildSpan("meep").start()
             .setBaggageItem("baggage-key", "baggage-value");
         final Span inactive = mockTracer.buildSpan("bleep").start()
             .setBaggageItem("baggage-key", "bleep-value");

--- a/src/test/java/org/zalando/opentracing/sqs/SQSTracingTestForAws2.java
+++ b/src/test/java/org/zalando/opentracing/sqs/SQSTracingTestForAws2.java
@@ -39,8 +39,8 @@ public class SQSTracingTestForAws2 {
 
     @Test
     public void producerMustLeaveRequestUnchangedForNullContext() {
-        mockTracer.buildSpan("meep").startActive(true).span()
-            .setBaggageItem("baggage-key", "baggage-value");
+        mockTracer.activateSpan(mockTracer.buildSpan("meep").start()
+                .setBaggageItem("baggage-key", "baggage-value"));
 
         final SendMessageRequest request = request();
         final SendMessageRequest traced = new SQSTracing(mockTracer).injectInto(request, null);
@@ -50,8 +50,8 @@ public class SQSTracingTestForAws2 {
 
     @Test
     public void producerMustAddSpanContextToSingleMessage() throws IOException {
-        mockTracer.buildSpan("meep").startActive(true).span()
-            .setBaggageItem("baggage-key", "baggage-value");
+        mockTracer.activateSpan(mockTracer.buildSpan("meep").ignoreActiveSpan().start()
+                .setBaggageItem("baggage-key", "baggage-value"));
 
         final String customName = "span_context";
 
@@ -78,7 +78,7 @@ public class SQSTracingTestForAws2 {
 
     @Test
     public void producerMustAddExplicitSpanContextToSingleMessage() throws IOException {
-        mockTracer.buildSpan("meep").startActive(true).span()
+        mockTracer.buildSpan("meep").start()
             .setBaggageItem("baggage-key", "baggage-value");
         final Span inactive = mockTracer.buildSpan("bleep").start()
             .setBaggageItem("baggage-key", "bleep-value");
@@ -118,8 +118,8 @@ public class SQSTracingTestForAws2 {
 
     @Test
     public void producerMustAddSpanContextToBatchEntry() throws IOException {
-        mockTracer.buildSpan("meep").startActive(true).span()
-            .setBaggageItem("baggage-key", "baggage-value");
+        mockTracer.activateSpan(mockTracer.buildSpan("meep").start()
+                .setBaggageItem("baggage-key", "baggage-value"));
 
         final SendMessageBatchRequestEntry request = entry();
         final SendMessageBatchRequestEntry traced = new SQSTracing(mockTracer)
@@ -153,7 +153,7 @@ public class SQSTracingTestForAws2 {
 
     @Test
     public void producerMustLeaveBatchRequestUnchangedForNullContext() {
-        mockTracer.buildSpan("meep").startActive(true).span()
+        mockTracer.buildSpan("meep").start()
             .setBaggageItem("baggage-key", "baggage-value");
 
         final SendMessageBatchRequest request = batch();
@@ -164,7 +164,7 @@ public class SQSTracingTestForAws2 {
 
     @Test
     public void producerMustAddSpanContextToWholeMessageBatch() {
-        mockTracer.buildSpan("meep").startActive(true).span()
+        mockTracer.buildSpan("meep").start()
             .setBaggageItem("baggage-key", "baggage-value");
         final Span inactive = mockTracer.buildSpan("bleep").start()
             .setBaggageItem("baggage-key", "bleep-value");
@@ -201,8 +201,8 @@ public class SQSTracingTestForAws2 {
 
     @Test
     public void producerMustAddExplicitSpanContextToWholeMessageBatch() {
-        mockTracer.buildSpan("meep").startActive(true).span()
-            .setBaggageItem("baggage-key", "baggage-value");
+        mockTracer.activateSpan(mockTracer.buildSpan("meep").start()
+                .setBaggageItem("baggage-key", "baggage-value"));
 
         final SendMessageBatchRequest request = batch();
         final SendMessageBatchRequest traced = new SQSTracing(mockTracer).injectInto(request);


### PR DESCRIPTION
# One-line summary

## Description
Update update-opentracing-api to 0.33.0 and fix occurring issues. This will allow for the project to be used with the newest telemetry-setup.

## Types of Changes
- Refactor/improvements
